### PR TITLE
`update-initramfs` requires `-c`, `-d` or `-u`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ modprobe r8152
 
 Make sure the driver gets loaded on system boot by rebuilding initramfs:
 ```
-$ update-initramfs
+$ update-initramfs -u
 ```
 
 You may now either (re)connect your USB Ethernet adapter.


### PR DESCRIPTION
In this case, `update-initramfs` requires `-u` during the call to update the current kernel